### PR TITLE
Closed ?:set= and ?:map= matchers; Spliced variants; non-unique item variant of set matcher 

### DIFF
--- a/src/pattern/matchers/set.clj
+++ b/src/pattern/matchers/set.clj
@@ -101,14 +101,34 @@
   If the pattern is variable but the minimum length is longer than the list
   length, no matches will be attempted. Otherwise the pattern length must match
   before attempting to match its contents."
-  [[_ item remainder :as pattern] comp-env]
+  [[t item remainder :as pattern] comp-env]
   (let [item-matcher (compile-pattern* item comp-env)
         literal (:literal (meta item-matcher))
+        no-check-set? (or (#{'?:item '??:item} t) (= false (:check-set? comp-env)))
         closed? (:closed? comp-env)
         item-var (var-name item)
-        remainder-matcher (when remainder (compile-pattern* remainder comp-env))]
-        ;; TODO get the remainder length and add 1. We can check the set size
-        ;; only check size before the first item
+        remainder-matcher (when remainder (compile-pattern* remainder comp-env))
+        remove-item (if no-check-set?
+                      (fn [coll item]
+                        (if (= item (first coll))
+                          (rest coll)
+                          (concat (take-while #(not= item %) coll) (next (drop-while #(not= item %) coll)))))
+                      disj)
+        find-item (if no-check-set?
+                    (fn [coll item not-found]
+                      (some #(when (or (= % item) (= % not-found)) %)
+                        (concat coll [not-found])))
+                    get)
+        flat? (= '??:item t)
+        extract (if flat? identity first)
+        recombine (if no-check-set?
+                    (fn [data after before]
+                      (if (vector? (extract data))
+                        (into [] (concat before after))
+                        (concat before after)))
+                    (fn [orig after before] (into after before)))]
+    ;; TODO get the remainder length and add 1. We can check the set size
+    ;; only check size before the first item
     (if (and literal closed? (not remainder))
       (compile-pattern* (list* '?:literal literal) comp-env)
       (with-meta
@@ -116,39 +136,46 @@
           (if (seq data)
             (letfn [(set-item-matcher [before after dictionary]
                       (let [datum (if-let [bound (when item-var (get dictionary item-var))]
-                                    (let [bound-val (get after (:value bound) ::not-found)]
-                                      (if (= ::not-found bound-val)
-                                        (first after)
-                                        bound-val))
-                                    (first after))
-                            after (disj after datum)]
-                        (if-let [result
-                                 (item-matcher
-                                   [datum]
-                                   dictionary
-                                   (assoc env :succeed
-                                     (fn match-set-succeed [new-dictionary n]
-                                       (if remainder-matcher
-                                         (let [remaining-set (into after before)]
-                                           (remainder-matcher [remaining-set] new-dictionary env))
-                                         (if (and closed? (or (seq before) (seq after)))
-                                           (on-failure :closed pattern new-dictionary env 1
-                                             (into after before) datum :retry retry)
-                                           ((.succeed env) new-dictionary 1))))))]
-                          result
-                          (retry (conj before datum) after))))
+                                    (find-item after (:value bound) ::not-found)
+                                    (first after))]
+                        (if (= ::not-found datum)
+                          (on-failure :not-found pattern dictionary env 1 (extract data)
+                            (:value (get dictionary item-var)) :retry retry)
+                          (let [after (remove-item after datum)]
+                            (if-let [result
+                                     (item-matcher
+                                       [datum]
+                                       dictionary
+                                       (assoc env :succeed
+                                         (fn match-set-succeed [new-dictionary n]
+                                           (if remainder-matcher
+                                             (let [remaining-set (recombine data after before)]
+                                               (remainder-matcher [remaining-set] new-dictionary
+                                                 (if flat?
+                                                   (assoc env :succeed
+                                                     (fn flat-succeed [new-dictionary n]
+                                                       ((.succeed env) new-dictionary
+                                                        (count (extract data)))))
+                                                   env)))
+                                             (if (and closed? (or (seq before) (seq after)))
+                                               (on-failure :closed pattern new-dictionary env 1
+                                                 (extract data) datum :retry retry)
+                                               ((.succeed env) new-dictionary
+                                                (if flat? (count (extract data)) 1)))))))]
+                              result
+                              (retry (conj before datum) after))))))
                     (retry [scanned-set remaining-set]
                       (if (seq remaining-set)
                         (bouncing (set-item-matcher scanned-set remaining-set dictionary))
                         (on-failure :mismatch pattern dictionary env 1 data remaining-set :retry retry)))]
-              (let [the-set (first data)]
-                (if (set? the-set)
+              (let [the-set (extract data)]
+                (if (or (set? the-set) no-check-set?)
                   (trampoline retry [] the-set)
                   (on-failure :type pattern dictionary env 1 data the-set :retry retry))))
             (on-failure :missing pattern dictionary env 0 data nil)))
         (merge (merge-meta (map meta [item-matcher remainder-matcher]))
-          { ;;:list-length list-length
-           :length (len 1)
+          {;;:list-length list-length
+           :length (if flat? (var-len 1) (len 1))
            `spliceable-pattern (fn [_] `(~'?:1 ~@pattern))})))))
 
 (register-matcher '?:open #'match-open)
@@ -157,6 +184,6 @@
 (register-matcher ':set #'match-set-literal) ;; register handler for set literal
 (register-matcher '?:set #'match-set {:aliases '[??:set ?:set= ??:set=]})
 (register-matcher '?:set-has #'match-set-has)
-(register-matcher '?:set-item #'match-set-item)
+(register-matcher '?:set-item #'match-set-item {:aliases '[?:item ??:item]})
 (register-matcher '?:set-intersection #'match-set-intersection)
 (register-matcher '?:*set #'match-*set {:aliases ['?:set*]})

--- a/src/pattern/r3/rewrite.clj
+++ b/src/pattern/r3/rewrite.clj
@@ -559,11 +559,6 @@
         (with-meta form# ~metadata)
         form#))))
 
-;; TODO: If the regular sub and subm methods all retained namespace, would that
-;; break anything? I think the behaviour may be leftover from the earliest
-;; versions of this functionality which tried to build off of stock
-;; backtick-quoted data, which was loaded with namespaces everywhere.
-
 (defn eval-spliced
   "Experimental. Uses [[spliced]] to transform regular lists, then uses eval to
   resolve spliced data. Doesn't resolve any data in the local scope."

--- a/test/pattern_test.clj
+++ b/test/pattern_test.clj
@@ -552,11 +552,6 @@
   (is (nil?
         (matcher '(?:+map ?k ?v) {}))))
 
-(deftest set-matcher
-  (is (= [[:b :a]]
-        (matcher '(?:set* ?k) #{:a :b}))))
-
-
 (deftest anon-matchers
   (is (= '(1)
         (matcher '[?x (?) (?)] [1 2 3])))
@@ -1022,6 +1017,18 @@
             (sum [ :x 1 2 3 :y 4 5 6 7 :z 1 2]))))))
 
 (deftest set-matchers
+  (is (= [[:b :a]]
+        (matcher '(?:set* ?k) #{:a :b})))
+
+  (is (nil? (matcher '[#{:a :b}] [#{}])))
+  (is (nil? (matcher '[#{:a :b}] [#{:a}])))
+  (is (nil? (matcher '[#{?_ (? _)}] [#{:a}])))
+  (is (= [] (matcher '[#{?_ (? _)}] [#{:a :b}])))
+
+  (is (= [[:c]] (matcher '[(??:set :a :b) ??x] [#{} :b :a :c])))
+  (is (= [[:c]] (matcher '[(??:set= :a :b) ??x] [:b :a :c])))
+  (is (nil? (matcher '[#{:a :b} ??x] [#{} :b :a :c])))
+
   (is (= []
         (matcher '[(?:set-has 20)] [#{1 10 20}])))
 

--- a/test/pattern_test.clj
+++ b/test/pattern_test.clj
@@ -1058,6 +1058,9 @@
   (is (nil? (matcher '(?:closed (?:set-item ?x (?:set-item 1))) #{1 2 3})))
   (is (#{2 3} (first (matcher '(?:set-item ?x (?:set-item 1)) #{1 2 3}))))
   (is (= [2] (matcher '(?:set-item ?x (?:set-item 1)) #{1 2})))
+  (is (nil? (matcher '[?x (?:set-item ?x (?:set-item 1))] [1 #{1 2}])))
+  (is (= [2] (matcher '[?x (?:set-item ?x (?:set-item 1))] [2 #{1 2}])))
+  (is (nil? (matcher '[?x (?:set-item ?x (?:set-item 1))] [3 #{1 2}])))
   (is (nil? (matcher '(?:set-item ?x (?:set-item 1)) #{1})))
   (is (some? '(?:closed (?:set-item ?x (?:open (?:set-item 1))))) #{1 2 3})
 
@@ -1214,3 +1217,18 @@
   (is (nil? (matcher '[(??:map :a ?_)] [:a])))
   (is (nil? (matcher '[(??:map= :a ?_)] [:a])))
   (is (nil? (matcher '[(??:map= :a)] [:a]))))
+
+(deftest test-item
+  (is (= '[2 (:a :b 1 :c)] (matcher '(?:item (? i = 2) (? other seq?)) '(:a :b 1 2 :c))))
+  (is (= '[1 [:a :b 2 :c]] (matcher '(?:item (? i int?) (? other vector?)) '[:a :b 1 2 :c])))
+  (is (= '[1 [:a :b 2 :c]] (matcher '[(??:item (? i int?) ?other)] '[:a :b 1 2 :c])))
+
+  (is (= '[2] (matcher '(?:item (? i = 2)) '(:a :b 1 2 :c))))
+  (is (= '[1] (matcher '(?:item (? i int?)) '[:a :b 1 2 :c])))
+  (is (= '[1] (matcher '[(??:item (? i int?))] '[:a :b 1 2 :c])))
+
+  (is (= '[2] (matcher '[?i (?:item (? i))] '[2 (:a :b 1 2 :c)])))
+  (is (nil? (matcher '[?i (?:item (? i int?) ?x)] '[3 [:a :b 1 2 :c]])))
+
+  (is (= [1 [:a :b 2 :c]] (matcher '[?i (??:item (? i int?) ?x)] '[1 :a :b 1 2 :c])))
+  (is (nil? (matcher '[?i (??:item (? i int?) ?x)] '[3 :a :b 1 2 :c]))))

--- a/test/pattern_test.clj
+++ b/test/pattern_test.clj
@@ -1102,6 +1102,13 @@
         x 1
         y 2]
     (is (= [#{1 2}] (sub [#{?x ?y}])))
+    (is (= [#{1 2}] (sub [(?:set ?x ?y)])))
+    (is (= [#{1 2}] (sub [(?:set= ?x ?y)])))
+    (is (= [#{}] (sub [(?:set)])))
+    (is (= [#{}] (sub [(?:set=)])))
+    (is (= [] (sub [(??:set)])))
+    (is (= [1 2] (sub [(??:set ?x ?y)])))
+    (is (= [1 2] (sub [(??:set= ?x ?y)])))
 
     (is (= [{1 2 2 1}] (sub [(?:closed {?x ?y ?y ?x})])))
 
@@ -1120,7 +1127,25 @@
     (is (= [{10 20 20 10 30 40}] (sub [(?:map-intersection {10 20 30 40} (?:map-kv ?v ?k))])))
 
     (is (= [{10 20 30 40}]
-          (sub [(?:map-intersection {10 ?v 30 40})])))))
+          (sub [(?:map-intersection {10 ?v 30 40})])))
+
+    (is (= [{10 20 20 10 30 40}] (sub [(?:map ?k ?v ?v ?k 30 40)])))
+    (is (= [{10 20 20 10 30 40}] (sub [(?:map= ?k ?v ?v ?k 30 40)])))
+    (is (= [{}] (sub [(?:map)])))
+    (is (= [{}] (sub [(?:map=)])))
+    (is (= [{10 nil}] (sub [(?:map ?k)])))
+    (is (= [{10 nil}] (sub [(?:map= ?k)]))))
+
+  (let [item :x
+        coll [:a :b]
+        list '(:a :b)]
+    (is (= '[(:x)] (sub [(?:item ?item)])))
+    (is (= [[:a :b :x]] (sub [(?:item ?item ?coll)])))
+    (is (= '[(:x :a :b)] (sub [(?:item ?item ?list)])))
+
+    (is (= '[:x] (sub [(??:item ?item)])))
+    (is (= [:a :b :x] (sub [(??:item ?item ?coll)])))
+    (is (= '[:x :a :b] (sub [(??:item ?item ?list)])))))
 
 (deftest more-map-matchers
   (is (= {:a 1 :b 2 10 :k}

--- a/test/pattern_test.clj
+++ b/test/pattern_test.clj
@@ -1155,7 +1155,9 @@
   (is (= [] (matcher '(?:map-kv :a 1) {:a 1 :b 2})))
 
   (is (= [] (matcher '[(?:map)] [{}])))
+  (is (= [] (matcher '[(?:map=)] [{}])))
   (is (= [] (matcher '[(?:map)] [{:a 1}])))
+  (is (= [] (matcher '[(?:map=)] [{:a 1}])))
   (is (= [] (matcher '[(?:closed (?:map))] [{}])))
   (is (nil? (matcher '[(?:closed (?:map))] [{:a 1}])))
 
@@ -1199,5 +1201,16 @@
                                       ?b 2}))))))
 
   (is (= [] (matcher '[(??:map :a 1)] [:a 1])))
+  (is (= [] (matcher '[(??:map= :a 1)] [:a 1])))
   (is (nil? (matcher '[(??:map ?a 1 ?b 1)] [:a 1 :b 1 :c])))
-  (is (= [:a :b] (matcher '[(??:map ?a 1 ?b 1)] [:a 1 :b 1 :c 1]))))
+  (is (= [:a :b] (matcher '[(??:map ?a 1 ?b 1)] [:a 1 :b 1 :c 1])))
+
+  (is (= [] (matcher '[(??:map :a)] [:a 1])))
+  (is (= [] (matcher '[(??:map :a ?_)] [:a 1])))
+  (is (= [] (matcher '[(??:map= :a ?_)] [:a 1])))
+  (is (= [] (matcher '[(??:map= :a)] [:a 1])))
+
+  (is (nil? (matcher '[(??:map :a)] [:a])))
+  (is (nil? (matcher '[(??:map :a ?_)] [:a])))
+  (is (nil? (matcher '[(??:map= :a ?_)] [:a])))
+  (is (nil? (matcher '[(??:map= :a)] [:a]))))


### PR DESCRIPTION
Using `?:set=`, I can specify that I want an exact set match. Same idea for map.

Also filled in the flat set variants which I think are useful:

`[(??:set x y z)]` lets me match a list with x y z in it in any order, or using `??:set=`, I can match a list that has only x y z in it in any order.