### PR TITLE
Remove match-plain-fn and the handful of places it was used.

### DIFF
--- a/src/pattern/match/core.clj
+++ b/src/pattern/match/core.clj
@@ -178,7 +178,7 @@
 (defgen= matcher-type [simple-ref?] '?:ref)
 (defgen= matcher-type [compiled-matcher?] :compiled-matcher)
 (defgen= matcher-type [compiled*-matcher?] :compiled*-matcher)
-(defgen= matcher-type [fn?] :plain-function)
+
 
 (defgenera= matcher-mode 1
   "Return the mode portion of the matcher, which is a string of any

--- a/src/pattern/matchers.clj
+++ b/src/pattern/matchers.clj
@@ -81,12 +81,6 @@
   [m comp-env]
   m)
 
-(defn- match-plain-function
-  "If a plain function is inserted into a pattern, treat it as the function in
-  an anonymous matcher with a restriction function."
-  [f comp-env]
-  (compile-pattern* (list '? '_ f) comp-env))
-
 (defn- match-list
   "Match a list or vector. If the first symbol with in the list is ?:seq, allows
   the matcher to match any type of list. Otherwise if the pattern is a vector,
@@ -1127,7 +1121,6 @@
 (register-matcher '?:= match-literal {:aliases ['?:literal]})
 (register-matcher :compiled-matcher match-compiled) ;; no rewrite
 (register-matcher :compiled*-matcher match-compiled*) ;; no rewrite
-(register-matcher :plain-function #'match-plain-function) ;; no rewrite
 (register-matcher '? #'match-element {:named? true})
 (register-matcher '?? #'match-segment {:named? true})
 (register-matcher '?:as #'match-as {:named? true :restriction-position 3})

--- a/src/pattern/matchers/map.clj
+++ b/src/pattern/matchers/map.clj
@@ -20,8 +20,8 @@
     (vary-meta
       (compile-pattern*
         (list* '&
-          map?
-          (fn check-map-intersection [x] (= map-literal (select-keys x map-keys)))
+          '(? _ map?)
+          (list '? '_ (fn check-map-intersection [x] (= map-literal (select-keys x map-keys))))
           (when remainder
             [(list '?:chain '?_ (fn dissoc-known [x] (apply dissoc x map-keys))
                remainder)]))
@@ -64,8 +64,8 @@
         (if patterns
           patterns
           (if closed?
-            (list '?:= {})
-            map?)))
+            '(?:= {})
+            '(? _ map?))))
       comp-env)))
 
 (defn match-map

--- a/src/pattern/matchers/set.clj
+++ b/src/pattern/matchers/set.clj
@@ -34,8 +34,8 @@
   (vary-meta
     (compile-pattern*
       (list* '&
-        set?
-        (fn check-intersection [x] (= set-literal (set/intersection set-literal x)))
+        '(? _ set?)
+        (list '? '_ (fn check-intersection [x] (= set-literal (set/intersection set-literal x))))
         (when remainder
           [(list '?:chain '?_ (fn remove-known [x] (set/difference x set-literal))
              remainder)]))
@@ -81,7 +81,7 @@
 (defn match-set-has
   "Create a ?:set-has matcher than can match an item in a set."
   [[_ item] comp-env]
-  (compile-pattern* (list '?:chain set? seq (list '??_ item '??_)) comp-env))
+  (compile-pattern* (list '?:chain '(? _ set?) seq (list '??_ item '??_)) comp-env))
 
 
 (defn match-*set

--- a/test/pattern_test.clj
+++ b/test/pattern_test.clj
@@ -1257,3 +1257,31 @@
 
   (is (= [1 [:a :b 2 :c]] (matcher '[?i (??:item (? i int?) ?x)] '[1 :a :b 1 2 :c])))
   (is (nil? (matcher '[?i (??:item (? i int?) ?x)] '[3 :a :b 1 2 :c]))))
+
+
+(deftest arbitrary-structures-match-themselves
+  (is (= ()
+        (matcher
+          [:a 'b {1 2 3 4} #{5 {[6 7] inc}}]
+          [:a 'b {1 2 3 4} #{5 {[6 7] inc}}])))
+
+  (is (= '(7)
+        (matcher
+          [:a 'b {1 2 3 4} #{5 {[6 '?a] inc}}]
+          [:a 'b {1 2 3 4} #{5 {[6 7]   inc}}])))
+
+  (is (nil?
+        (matcher
+          [:a 'b {1 2 3 4} #{5 {[6 7] inc}}]
+          [:a 'b {1 2 3 4} #{5 {[6 7] identity}}])))
+
+  (is (= ()
+        (matcher
+          [:a 'b {1 2 3 4}     #{5 {[6 7] inc}}]
+          [:a 'b {1 2 3 4 5 6} #{5 {[6 7] inc 7 8} 9 10}]))
+    "maps and sets are open!")
+
+  (is (nil?
+        (matcher
+          [:a 'b {1 2 3 4 5 6} #{5 {[6 7] inc 7 8} 9 10}]
+          [:a 'b {1 2 3 4}     #{5 {[6 7] inc}}]))))


### PR DESCRIPTION
I rarely used this in practice except within other rule definitions, and it I didn't like the way it would make what looks like a simple constant match against a datastructure that contains a function actually instead call the function present in the pattern during matching. This limited the ability to match against arbitrary data structures.