### PR TITLE
Fix StackOverflow in ?:* sequence matcher for large sequences

### DIFF
--- a/src/pattern/matchers.clj
+++ b/src/pattern/matchers.clj
@@ -545,35 +545,53 @@
                               (update-in dict [var-name :value] conj nil)
                               dict)))
                   dict matcher-vars))
-              (gather [dict n data env matches]
-                (if (and (if (symbol? at-most)
-                           ;; no match if undefined
-                           (< (.repetition ^Env env) (:value (dict at-most) 0))
-                           (< (.repetition ^Env env) at-most))
-                      (has-n? reserve-min-tail data))
-                  (bouncing
-                    (or (match-part
-                          data dict
-                          (assoc env
-                            :succeed
-                            (fn seq-succeed [dict n']
-                              (if (zero? n')
-                                (if (>= (.repetition ^Env env) 1)
-                                  matches
-                                  (let [reps (inc (.repetition ^Env env))
-                                        dict (level-sequences reps dict)]
-                                    (if (test-match reps dict)
-                                      (conj matches [dict n])
-                                      matches)))
-                                (let [reps (inc (.repetition ^Env env))
-                                      dict (level-sequences reps dict)]
-                                  (gather dict (+ n n') (drop n' data)
-                                    (assoc env :repetition reps)
-                                    (if (test-match reps dict)
-                                      (conj matches [dict (+ n n')])
-                                      matches)))))))
-                      matches))
-                  matches))]
+              ;; Iterative gather: matches one repetition at a time using
+              ;; match-part synchronously via atom capture. Avoids O(n) stack
+              ;; depth for n repetitions (the recursive callback chain in the
+              ;; original gather overflows around 500-600 repetitions).
+              ;; Also handles zero-length matches: when match-part succeeds but
+              ;; consumes 0 elements and we already have ≥1 repetition, stop
+              ;; to prevent infinite loops.
+              (gather-iterative [dict n data env matches]
+                (loop [dict dict, n n, data data, env env, matches matches]
+                  (if (and (if (symbol? at-most)
+                             (< (.repetition ^Env env) (:value (dict at-most) 0))
+                             (< (.repetition ^Env env) at-most))
+                        (has-n? reserve-min-tail data))
+                    ;; Try matching one repetition synchronously
+                    (let [result (atom nil)
+                          matched (match-part
+                                    data dict
+                                    (assoc env
+                                      :succeed
+                                      (fn [dict' n']
+                                        (reset! result [dict' n'])
+                                        true)))]
+                      (if (and matched @result)
+                        (let [[new-dict n'] @result]
+                          (if (zero? n')
+                            ;; Zero-length match: if we already have ≥1 rep, stop
+                            ;; to prevent infinite loop. Otherwise count it once.
+                            (if (>= (.repetition ^Env env) 1)
+                              matches
+                              (let [reps (inc (.repetition ^Env env))
+                                    new-dict (level-sequences reps new-dict)]
+                                (if (test-match reps new-dict)
+                                  (conj matches [new-dict n])
+                                  matches)))
+                            ;; Normal match: consumed n' elements
+                            (let [reps (inc (.repetition ^Env env))
+                                  new-dict (level-sequences reps new-dict)
+                                  new-matches (if (test-match reps new-dict)
+                                                (conj matches [new-dict (+ n n')])
+                                                matches)]
+                              (recur new-dict (+ n n') (drop n' data)
+                                     (assoc env :repetition reps)
+                                     new-matches))))
+                        ;; match-part failed, stop gathering
+                        matches))
+                    ;; limit reached or no more data
+                    matches)))]
         (with-meta
           (fn many-matcher [data dictionary ^Env env]
             (let [dict (reduce (fn [d var] ;; Populate the dictionary with a set of empty matches if none exist
@@ -583,16 +601,15 @@
                            :sequence/id (gensym))
                          matcher-vars)
                   matches
-                  (trampolining
-                    (gather dict 0 data
-                      ;; Alter lookup behavior and make no-match in match-optional fail
-                      (assoc env
-                        :lookup sequence-lookup
-                        :store sequence-extend-dict
-                        :repetition 0)
-                      (if (test-match 0 dict)
-                        [[dict 0]]
-                        [])))]
+                  (gather-iterative dict 0 data
+                    ;; Alter lookup behavior and make no-match in match-optional fail
+                    (assoc env
+                      :lookup sequence-lookup
+                      :store sequence-extend-dict
+                      :repetition 0)
+                    (if (test-match 0 dict)
+                      [[dict 0]]
+                      []))]
               (loop [matches matches]
                 (when-let [[dict n] (peek matches)]
                   (or ((.succeed env) dict n)


### PR DESCRIPTION
## Problem

The `?:*` (and friends) sequence matcher overflows the stack on large
sequences. `gather` recursed through the `seq-succeed` callback chain under
`trampolining`, consuming O(n) stack frames for n repetitions — it blows up
around 500–600 elements.

## Fix

Replace the recursive gather with an iterative `loop`/`recur` version
(`gather-iterative`) that captures each `match-part` result synchronously via
an atom and recurs, so stack depth is O(1) in the number of repetitions. The
rewrite also keeps the zero-length-match guard: if `match-part` succeeds but
consumes 0 elements and we already have ≥1 repetition, it stops rather than
looping forever.

## Validation

- Tested with 5000-element sequences — no overflow (previously overflowed
  ~500–600).
- All existing matcher tests pass (`pattern-test`, `sub-test`,
  `predicator-test`, `simplify-test`, `r3-test`, `nanopass-test`):
  **87 tests / 617 assertions, 0 failures**.

Single-file change in `src/pattern/matchers.clj`. This has been running in
production in our downstream fork; opening it upstream so the fix lands in
`com.github.pangloss/pattern` directly.
